### PR TITLE
Medientheorie?

### DIFF
--- a/angry-bot.js
+++ b/angry-bot.js
@@ -162,6 +162,14 @@ client.on("message", msg => {
         StatHandler.incrementStat(StatHandler.DIVOTKEY_REACTIONS);
     }
 
+    // Medientheorie
+    if (
+        msg.cleanContent.toLocaleLowerCase().includes("medien") &&
+        msg.cleanContent.toLocaleLowerCase().includes("theorie") 
+    ) {
+        msg.reply(`MEDIENTHEORIE :heart_eyes::heart_eyes::heart_eyes:`);
+    }
+
     // Sanctoin russia
     if (
         msg.cleanContent.toLocaleLowerCase().includes("russia") ||


### PR DESCRIPTION
Als Medientheorie werden spezifische oder generalisierte Forschungsansätze verstanden, die das Wesen und die Wirkungsweise von Einzelmedien oder der Massenmedien generell zu erklären versuchen. Es werden darin häufig Rückbezüge genommen auf die Kommunikations- und die Informationstheorie.

Die Medientheorie ist neben der Medienanalyse und der Mediengeschichte eines der drei zentralen Arbeitsfelder der Medienwissenschaft.